### PR TITLE
Add type support and fix string escaping in yaml2dart

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
 
@@ -29,8 +30,13 @@ class Yaml2Dart {
 
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
-      key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      key = ReCase(key.toString()).camelCase;
+      try {
+        final encoded = jsonEncode(value);
+        buffer.writeln('const $key = $encoded;');
+      } catch (e) {
+        buffer.writeln('const $key = \'$value\';');
+      }
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -28,12 +28,51 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
 '''));
     } finally {
       // Clean up the temporary directory.
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('Converts YAML with types and escaping', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_test_types_');
+    final inputPath = path.join(tempDir.path, 'test_input.yaml');
+    final outputPath = path.join(tempDir.path, 'test_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+title: "My App's Name"
+version: 1.0
+build: 10
+enabled: true
+list: [1, 2]
+map: {a: 1}
+123: "numeric key"
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      final content = await outputFile.readAsString();
+
+      // Check for expected output with types
+      expect(content, contains('const title = "My App\'s Name";'));
+      expect(content, contains('const version = 1.0;'));
+      expect(content, contains('const build = 10;'));
+      expect(content, contains('const enabled = true;'));
+      expect(content, contains('const list = [1,2];'));
+      expect(content, contains('const map = {"a":1};'));
+      // Verify numeric key handling (converted to string key internally for ReCase)
+      expect(content, contains('const 123 = "numeric key";'));
+
+    } finally {
       await tempDir.delete(recursive: true);
     }
   });


### PR DESCRIPTION
This change improves the `yaml2dart` converter by preserving YAML types in the generated Dart code. Previously, all values were treated as strings. Now, integers, doubles, booleans, lists, and maps are generated as their respective Dart types. This also fixes an issue with string escaping and prevents crashes when YAML keys are not strings. Tests were updated to expect double quotes (standard JSON encoding) and a new test case was added for type verification.

---
*PR created automatically by Jules for task [10923895950903846709](https://jules.google.com/task/10923895950903846709) started by @insign*