### PR TITLE
Support typed constants for int, double, bool, List, and Map

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
@@ -30,7 +31,11 @@ class Yaml2Dart {
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
       key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      try {
+        buffer.writeln('const $key = ${jsonEncode(value)};');
+      } catch (e) {
+        buffer.writeln('const $key = \'$value\';');
+      }
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -17,6 +17,11 @@ void main() {
         title: My App
         version: 1.2.3
         author: John Doe
+        build: 100
+        enabled: true
+        pi: 3.14
+        features: ["dark_mode", "beta"]
+        config: {timeout: 3000}
 ''');
 
       // Convert the YAML file to a Dart file.
@@ -26,11 +31,17 @@ void main() {
       // Verify that the output Dart file exists and has the correct contents.
       final outputFile = File(outputPath);
       expect(await outputFile.exists(), isTrue);
+      // jsonEncode produces double quotes for strings and standard JSON format for lists/maps.
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
+const build = 100;
+const enabled = true;
+const pi = 3.14;
+const features = ["dark_mode","beta"];
+const config = {"timeout":3000};
 '''));
     } finally {
       // Clean up the temporary directory.


### PR DESCRIPTION
This change improves the `yaml2dart` utility by generating typed Dart constants for YAML values. Previously, all values were treated as strings. Now, integers, doubles, booleans, lists, and maps are generated as their native Dart types where possible, using `jsonEncode`. This provides better type safety and more idiomatic Dart code generation. Backward compatibility is maintained for complex objects that cannot be JSON encoded by falling back to the string representation. tests were updated to reflect the new behavior.

---
*PR created automatically by Jules for task [13987308637913240428](https://jules.google.com/task/13987308637913240428) started by @insign*