### PR TITLE
Support typed Dart constants from YAML

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
@@ -28,10 +29,12 @@ class Yaml2Dart {
     buffer.writeln(warning);
 
     // Write each key-value pair in the YAML file as a Dart constant.
-    yaml.forEach((key, value) {
-      key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
-    });
+    if (yaml is Map) {
+      yaml.forEach((key, value) {
+        key = ReCase(key.toString()).camelCase;
+        buffer.writeln('const $key = ${jsonEncode(value)};');
+      });
+    }
 
     // Write the contents to the output file.
     await output.writeAsString(buffer.toString());

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -28,12 +28,48 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
 '''));
     } finally {
       // Clean up the temporary directory.
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('Converts mixed YAML types to Dart constants', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_mixed_');
+    final inputPath = path.join(tempDir.path, 'mixed_input.yaml');
+    final outputPath = path.join(tempDir.path, 'mixed_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        count: 42
+        ratio: 3.14
+        isEnabled: true
+        items:
+          - one
+          - two
+        config:
+          debug: false
+          max: 100
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.readAsString(), equals('''
+${converter.warning}
+const count = 42;
+const ratio = 3.14;
+const isEnabled = true;
+const items = ["one","two"];
+const config = {"debug":false,"max":100};
+'''));
+    } finally {
       await tempDir.delete(recursive: true);
     }
   });


### PR DESCRIPTION
Improved `yaml2dart` to generate typed Dart constants instead of converting everything to strings.
Used `jsonEncode` to handle serialization of values, preserving `int`, `double`, `bool`, `List`, and `Map` types.
Also improved robustness by checking if `yaml` is a Map and converting keys to strings before CamelCase conversion.
Added a test case for mixed types and updated existing tests to match the new output format (double quotes).

---
*PR created automatically by Jules for task [2839821248738943232](https://jules.google.com/task/2839821248738943232) started by @insign*