### PR TITLE
feat: Support type inference for Dart constants from YAML

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
@@ -24,13 +25,15 @@ class Yaml2Dart {
     // Create the output Dart file.
     final output = File(outputFilePath);
     final buffer = StringBuffer();
+    final encoder = JsonEncoder.withIndent('  ');
 
     buffer.writeln(warning);
 
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
       key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      var encodedValue = encoder.convert(value).replaceAll(r'$', r'\$');
+      buffer.writeln('const $key = $encodedValue;');
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -15,7 +15,7 @@ void main() {
       final inputFile = File(inputPath);
       await inputFile.writeAsString('''
         title: My App
-        version: 1.2.3
+        version: "1.2.3"
         author: John Doe
 ''');
 
@@ -28,12 +28,68 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
 '''));
     } finally {
       // Clean up the temporary directory.
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('Converts complex YAML types to Dart constants', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_complex_test_');
+    final inputPath = path.join(tempDir.path, 'complex_input.yaml');
+    final outputPath = path.join(tempDir.path, 'complex_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        count: 42
+        pi: 3.14
+        is_awesome: true
+        features:
+          - fast
+          - reliable
+        config:
+          debug: false
+          timeout: 100
+        special: "Price: \$10"
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      final content = await outputFile.readAsString();
+
+      // Check for existence and basic structure
+      expect(await outputFile.exists(), isTrue);
+
+      // We expect JSON-encoded values with indentation.
+      // Note: JsonEncoder uses 2-space indentation.
+      // List and Map will be spread across lines.
+
+      final expectedOutput = '''
+${converter.warning}
+const count = 42;
+const pi = 3.14;
+const isAwesome = true;
+const features = [
+  "fast",
+  "reliable"
+];
+const config = {
+  "debug": false,
+  "timeout": 100
+};
+const special = "Price: \\\$10";
+''';
+
+      expect(content, equals(expectedOutput));
+
+    } finally {
       await tempDir.delete(recursive: true);
     }
   });


### PR DESCRIPTION
This PR improves `yaml2dart` by using `JsonEncoder` to generate Dart constants.
Previously, all YAML values were treated as strings and wrapped in single quotes.
This change allows `yaml2dart` to generate:
- `bool` constants (e.g., `const debug = true;`)
- `num` constants (e.g., `const port = 8080;`)
- `List` and `Map` constants (e.g., `const items = ["a", "b"];`)
- Properly escaped strings (using double quotes and escaping `$`).

This ensures generated code is type-safe and valid Dart.

---
*PR created automatically by Jules for task [16577963687122711241](https://jules.google.com/task/16577963687122711241) started by @insign*