### PR TITLE
Support typed Dart constants generation from YAML

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
@@ -30,7 +31,7 @@ class Yaml2Dart {
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
       key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      buffer.writeln('const $key = ${jsonEncode(value)};');
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
@@ -28,12 +29,52 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
 '''));
     } finally {
       // Clean up the temporary directory.
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  test('Converts YAML mixed types to Dart constants', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_mixed_test_');
+    final inputPath = path.join(tempDir.path, 'mixed_input.yaml');
+    final outputPath = path.join(tempDir.path, 'mixed_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+count: 10
+isEnabled: true
+ratio: 3.14
+items:
+  - one
+  - two
+config:
+  debug: false
+quote: "It's me"
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+
+      // Note: jsonEncode produces compact JSON.
+      expect(await outputFile.readAsString(), equals('''
+${converter.warning}
+const count = 10;
+const isEnabled = true;
+const ratio = 3.14;
+const items = ["one","two"];
+const config = {"debug":false};
+const quote = "It's me";
+'''));
+    } finally {
       await tempDir.delete(recursive: true);
     }
   });


### PR DESCRIPTION
Improved the YAML to Dart conversion to support typed constants (int, double, bool, List, Map) and correct string escaping by using `jsonEncode`. Previously, all values were generated as strings, which could lead to incorrect types and syntax errors with unescaped quotes.

Key changes:
- `lib/src/yaml2dart_base.dart`: Replaced manual string interpolation with `jsonEncode` for value generation.
- `test/yaml2dart_test.dart`: Updated existing tests to expect double quotes (default for JSON) and added a new test case for mixed types and special characters.

---
*PR created automatically by Jules for task [13254326277026858045](https://jules.google.com/task/13254326277026858045) started by @insign*