### PR TITLE
Improve type handling and fix escaping in generated Dart code

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
+import 'dart:convert';
 
 /// A utility class for converting YAML files to Dart constants.
 class Yaml2Dart {
@@ -30,7 +31,14 @@ class Yaml2Dart {
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
       key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      try {
+        final encoded = jsonEncode(value);
+        buffer.writeln('const $key = $encoded;');
+      } catch (e) {
+        // Fallback for types jsonEncode cannot handle
+        final stringValue = value.toString().replaceAll("'", "\\'");
+        buffer.writeln('const $key = \'$stringValue\';');
+      }
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -14,9 +14,13 @@ void main() {
       // Write the input YAML file.
       final inputFile = File(inputPath);
       await inputFile.writeAsString('''
-        title: My App
-        version: 1.2.3
-        author: John Doe
+title: My App
+version: 1.2.3
+author: John Doe
+build: 10
+rating: 4.5
+enabled: true
+features: [a, b]
 ''');
 
       // Convert the YAML file to a Dart file.
@@ -28,9 +32,13 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const title = "My App";
+const version = "1.2.3";
+const author = "John Doe";
+const build = 10;
+const rating = 4.5;
+const enabled = true;
+const features = ["a","b"];
 '''));
     } finally {
       // Clean up the temporary directory.


### PR DESCRIPTION
Modified `Yaml2Dart` to use `jsonEncode` for value conversion. This allows for correct generation of `int`, `double`, `bool`, `List`, and `Map` constants, and fixes a bug where single quotes in strings were not properly escaped. Added a fallback mechanism for values that cannot be JSON encoded. Updated tests to reflect these changes.

---
*PR created automatically by Jules for task [6368580579685789719](https://jules.google.com/task/6368580579685789719) started by @insign*