### PR TITLE
Support dynamic types and correct serialization of Dart constants

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:convert';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
 
@@ -14,6 +15,19 @@ class Yaml2Dart {
   /// [outputFilePath] is the path to the output Dart file.
   Yaml2Dart(this.inputFilePath, this.outputFilePath);
 
+  dynamic _convertNode(dynamic node) {
+    if (node is YamlMap) {
+      final map = <String, dynamic>{};
+      node.forEach((key, value) {
+        map[key.toString()] = _convertNode(value);
+      });
+      return map;
+    } else if (node is YamlList) {
+      return node.map((e) => _convertNode(e)).toList();
+    }
+    return node;
+  }
+
   /// Converts the input YAML file to a Dart file containing constants.
   Future<void> convert() async {
     // Read the YAML file.
@@ -27,11 +41,29 @@ class Yaml2Dart {
 
     buffer.writeln(warning);
 
-    // Write each key-value pair in the YAML file as a Dart constant.
-    yaml.forEach((key, value) {
-      key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
-    });
+    if (yaml is Map) {
+      // Write each key-value pair in the YAML file as a Dart constant.
+      yaml.forEach((key, value) {
+        final camelCaseKey = ReCase(key.toString()).camelCase;
+        final dartValue = _convertNode(value);
+
+        String type = '';
+        if (dartValue is String) {
+          type = 'String ';
+        } else if (dartValue is num) {
+          type = 'num ';
+        } else if (dartValue is bool) {
+          type = 'bool ';
+        } else if (dartValue is List) {
+          type = 'List ';
+        } else if (dartValue is Map) {
+          type = 'Map ';
+        }
+
+        final encodedValue = jsonEncode(dartValue);
+        buffer.writeln('const $type$camelCaseKey = $encodedValue;');
+      });
+    }
 
     // Write the contents to the output file.
     await output.writeAsString(buffer.toString());

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -14,9 +14,16 @@ void main() {
       // Write the input YAML file.
       final inputFile = File(inputPath);
       await inputFile.writeAsString('''
-        title: My App
-        version: 1.2.3
-        author: John Doe
+title: My App
+version: 1.2.3
+author: John Doe
+count: 5
+isActive: true
+items:
+  - a
+  - b
+config:
+  key: value
 ''');
 
       // Convert the YAML file to a Dart file.
@@ -28,9 +35,13 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const String title = "My App";
+const String version = "1.2.3";
+const String author = "John Doe";
+const num count = 5;
+const bool isActive = true;
+const List items = ["a","b"];
+const Map config = {"key":"value"};
 '''));
     } finally {
       // Clean up the temporary directory.


### PR DESCRIPTION
This change improves yaml2dart by dynamically inferring the types (String, num, bool, List, Map) from the parsed YAML nodes and writing explicit typed constants in the generated Dart file. It recursively converts `YamlMap` and `YamlList` to standard Maps and Lists, and uses `jsonEncode` for safe, proper serialization of values into dart literal syntax. The unit tests are also updated to ensure functionality and syntax format.

---
*PR created automatically by Jules for task [11918752170024817686](https://jules.google.com/task/11918752170024817686) started by @insign*