### PR TITLE
Add type inference to YAML code generator

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,6 +1,25 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
+
+Object? _convertNode(Object? node) {
+  if (node is YamlMap) {
+    return node.map((key, value) => MapEntry(key.toString(), _convertNode(value)));
+  } else if (node is YamlList) {
+    return node.map(_convertNode).toList();
+  }
+  return node;
+}
+
+String _getType(Object? value) {
+  if (value is String) return 'String';
+  if (value is num) return 'num';
+  if (value is bool) return 'bool';
+  if (value is List) return 'List';
+  if (value is Map) return 'Map';
+  return 'dynamic';
+}
 
 /// A utility class for converting YAML files to Dart constants.
 class Yaml2Dart {
@@ -29,8 +48,19 @@ class Yaml2Dart {
 
     // Write each key-value pair in the YAML file as a Dart constant.
     yaml.forEach((key, value) {
-      key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
+      final camelKey = ReCase(key.toString()).camelCase;
+      final convertedValue = _convertNode(value);
+      final type = _getType(convertedValue);
+
+      String serializedValue;
+      if (convertedValue is String) {
+        final escapedString = convertedValue.replaceAll(r'\', r'\\').replaceAll("'", r"\'").replaceAll(r'$', r'\$').replaceAll('\n', r'\n').replaceAll('\r', r'\r');
+        serializedValue = "'$escapedString'";
+      } else {
+        serializedValue = jsonEncode(convertedValue);
+      }
+
+      buffer.writeln('const $type $camelKey = $serializedValue;');
     });
 
     // Write the contents to the output file.

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -17,6 +17,14 @@ void main() {
         title: My App
         version: 1.2.3
         author: John Doe
+        price: "100\$"
+        is_active: true
+        count: 42
+        data:
+          key1: val1
+        items:
+          - 1
+          - 2
 ''');
 
       // Convert the YAML file to a Dart file.
@@ -28,9 +36,14 @@ void main() {
       expect(await outputFile.exists(), isTrue);
       expect(await outputFile.readAsString(), equals('''
 ${converter.warning}
-const title = 'My App';
-const version = '1.2.3';
-const author = 'John Doe';
+const String title = 'My App';
+const String version = '1.2.3';
+const String author = 'John Doe';
+const String price = '100\\\$';
+const bool isActive = true;
+const num count = 42;
+const Map data = {"key1":"val1"};
+const List items = [1,2];
 '''));
     } finally {
       // Clean up the temporary directory.


### PR DESCRIPTION
This change improves the `yaml2dart` utility. Previously, all YAML values were treated as Dart strings and written as `const key = 'value';` without considering types. Now, this infers boolean, numbers, Lists, Maps, and dynamic values, correctly serializing them into type-safe Dart constants with correct escaping for strings (including variables starting with `$`).

---
*PR created automatically by Jules for task [5003952150295008006](https://jules.google.com/task/5003952150295008006) started by @insign*