### PR TITLE
Improve yaml2dart type conversion and string escaping

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 import 'package:yaml/yaml.dart';
 import 'package:recase/recase.dart';
@@ -14,6 +15,30 @@ class Yaml2Dart {
   /// [outputFilePath] is the path to the output Dart file.
   Yaml2Dart(this.inputFilePath, this.outputFilePath);
 
+  dynamic _convertNode(dynamic node) {
+    if (node is YamlMap) {
+      return node.map((key, value) => MapEntry(key.toString(), _convertNode(value)));
+    } else if (node is YamlList) {
+      return node.map(_convertNode).toList();
+    }
+    return node;
+  }
+
+  String _formatValue(dynamic value) {
+    if (value is String) {
+      final escaped = value.replaceAll(r'\', r'\\').replaceAll("'", r"\'").replaceAll(r'$', r'\$');
+      return "'$escaped'";
+    } else if (value is num || value is bool) {
+      return value.toString();
+    } else if (value == null) {
+      return 'null';
+    } else {
+      final plainObject = _convertNode(value);
+      final jsonString = jsonEncode(plainObject);
+      return jsonString.replaceAll(r'$', r'\$');
+    }
+  }
+
   /// Converts the input YAML file to a Dart file containing constants.
   Future<void> convert() async {
     // Read the YAML file.
@@ -27,11 +52,14 @@ class Yaml2Dart {
 
     buffer.writeln(warning);
 
-    // Write each key-value pair in the YAML file as a Dart constant.
-    yaml.forEach((key, value) {
-      key = ReCase(key).camelCase;
-      buffer.writeln('const $key = \'$value\';');
-    });
+    if (yaml is YamlMap) {
+      // Write each key-value pair in the YAML file as a Dart constant.
+      yaml.forEach((key, value) {
+        final keyString = ReCase(key.toString()).camelCase;
+        final formattedValue = _formatValue(value);
+        buffer.writeln('const $keyString = $formattedValue;');
+      });
+    }
 
     // Write the contents to the output file.
     await output.writeAsString(buffer.toString());

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -17,6 +17,15 @@ void main() {
         title: My App
         version: 1.2.3
         author: John Doe
+        numValue: 42
+        boolValue: true
+        strWithQuote: "it's"
+        strWithDollar: "\$10"
+        strWithBackslash: "a\\\\b"
+        nestedList: [1, "two\$", 3.0]
+        nestedMap:
+          key1: "val\$1"
+          key2: 2
 ''');
 
       // Convert the YAML file to a Dart file.
@@ -31,6 +40,13 @@ ${converter.warning}
 const title = 'My App';
 const version = '1.2.3';
 const author = 'John Doe';
+const numValue = 42;
+const boolValue = true;
+const strWithQuote = 'it\\'s';
+const strWithDollar = '\\\$10';
+const strWithBackslash = 'a\\\\b';
+const nestedList = [1,"two\\\$",3.0];
+const nestedMap = {"key1":"val\\\$1","key2":2};
 '''));
     } finally {
       // Clean up the temporary directory.


### PR DESCRIPTION
Improve the yaml2dart package to support exporting YAML values into Dart constants with their native types (String, num, bool, List, Map) instead of always casting them as strings. Also correctly escape problematic string characters (like $, \, and ') to avoid Dart parsing errors. Add test cases to cover the new behavior.

---
*PR created automatically by Jules for task [12709814624522012074](https://jules.google.com/task/12709814624522012074) started by @insign*