### PR TITLE
feat: create output directory if missing

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -69,6 +69,7 @@ class Yaml2Dart {
     }
 
     // Write the contents to the output file.
+    await output.parent.create(recursive: true);
     await output.writeAsString(buffer.toString());
   }
 }

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -83,4 +83,27 @@ const author = 'John Doe';
       await tempDir.delete(recursive: true);
     }
   });
+
+  test('Creates output directories if they do not exist', () async {
+    final tempDir =
+        await Directory.systemTemp.createTemp('yaml2dart_dir_test_');
+    final inputPath = path.join(tempDir.path, 'dir_input.yaml');
+    final outputPath = path.join(tempDir.path, 'nested', 'missing', 'dir_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        title: App
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      expect(await outputFile.readAsString(), contains("const title = 'App';"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
This PR automatically creates the parent directory of the output Dart file, ensuring that the script does not crash with a PathNotFoundException when the user supplies an output path inside a directory that does not yet exist. A unit test was added to verify the nested directory creation.

---
*PR created automatically by Jules for task [8025950146412148658](https://jules.google.com/task/8025950146412148658) started by @insign*