### PR TITLE
feat: automatically create missing output directories

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -57,6 +57,9 @@ class Yaml2Dart {
 
     // Create the output Dart file.
     final output = File(outputFilePath);
+    if (!await output.parent.exists()) {
+      await output.parent.create(recursive: true);
+    }
     final buffer = StringBuffer();
 
     buffer.writeln(warning);

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -83,4 +83,26 @@ const author = 'John Doe';
       await tempDir.delete(recursive: true);
     }
   });
+
+  test('Creates output directories if they do not exist', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_dirs_test_');
+    final inputPath = path.join(tempDir.path, 'input.yaml');
+    final outputDirPath = path.join(tempDir.path, 'nested', 'dirs', 'here');
+    final outputPath = path.join(outputDirPath, 'output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('name: TestApp\n');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      final content = await outputFile.readAsString();
+      expect(content, contains("const name = 'TestApp';"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
This pull request adds a small improvement to the `yaml2dart` library to automatically create the missing parent directories for the output Dart file during generation.

When specifying an output path like `lib/constants/config.dart` where `constants` does not exist, the library used to throw a `PathNotFoundException`. This update automatically creates the necessary directories using `await output.parent.create(recursive: true);`.

It also includes a unit test to verify that nested directories are created correctly without errors. No temporary files have been committed.

---
*PR created automatically by Jules for task [11873597992628403027](https://jules.google.com/task/11873597992628403027) started by @insign*