### PR TITLE
Fix Dart invalid constant names from YAML keywords and digit keys

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -64,9 +64,22 @@ class Yaml2Dart {
 
     buffer.writeln(warning);
 
+    const dartReservedKeywords = {
+      'assert', 'break', 'case', 'catch', 'class', 'const', 'continue',
+      'default', 'do', 'else', 'enum', 'extends', 'false', 'final',
+      'finally', 'for', 'if', 'in', 'is', 'new', 'null', 'rethrow',
+      'return', 'super', 'switch', 'this', 'throw', 'true', 'try',
+      'var', 'void', 'while', 'with',
+    };
+
     if (yaml is YamlMap) {
       yaml.forEach((key, value) {
-        final keyString = ReCase(key.toString()).camelCase;
+        var keyString = ReCase(key.toString()).camelCase;
+        if (dartReservedKeywords.contains(keyString)) {
+          keyString = '${keyString}_';
+        } else if (keyString.startsWith(RegExp(r'[0-9]'))) {
+          keyString = '\$$keyString';
+        }
         buffer.writeln('const $keyString = ${_formatValue(value)};');
       });
     }

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -105,4 +105,37 @@ const author = 'John Doe';
       await tempDir.delete(recursive: true);
     }
   });
+
+  test('Sanitizes Dart reserved keywords and keys starting with digits', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_sanitize_test_');
+    final inputPath = path.join(tempDir.path, 'sanitize_input.yaml');
+    final outputPath = path.join(tempDir.path, 'sanitize_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        class: my_class
+        default: true
+        1st_item: first
+        _private: private
+        return: 10
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      final content = await outputFile.readAsString();
+
+      // Verify sanitized constants
+      expect(content, contains("const class_ = 'my_class';"));
+      expect(content, contains("const default_ = true;"));
+      expect(content, contains("const \$1stItem = 'first';"));
+      expect(content, contains("const private = 'private';"));
+      expect(content, contains("const return_ = 10;"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
This PR sanitizes generated Dart constant names that clash with reserved keywords or start with a digit, preventing compilation errors in the output.

By default, YAML keys like `class` or `1st_item` caused invalid Dart to be generated (e.g., `const class = ...;` or `const 1stItem = ...;`). This fix automatically appends an underscore to the 33 Dart reserved keywords (e.g., `class_`) and prefixes keys starting with a digit with a dollar sign (e.g., `$1stItem`). This ensures that output Dart code is always syntactically valid and compilation does not fail.

A new test covering these specific edge cases was also added.

---
*PR created automatically by Jules for task [4306166872838369448](https://jules.google.com/task/4306166872838369448) started by @insign*