### PR TITLE
Fix unnecessary string escapes in generated Dart constants

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -33,6 +33,7 @@ class Yaml2Dart {
       final encoded = jsonEncode(value);
       final escaped = encoded
           .substring(1, encoded.length - 1)
+          .replaceAll(r'\"', '"')
           .replaceAll("'", r"\'")
           .replaceAll(r'$', r'\$');
       return "'$escaped'";

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -182,4 +182,31 @@ const author = 'John Doe';
       await tempDir.delete(recursive: true);
     }
   });
+
+  test('Avoids unnecessary escaping of double quotes in strings', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_quotes_test_');
+    final inputPath = path.join(tempDir.path, 'quotes_input.yaml');
+    final outputPath = path.join(tempDir.path, 'quotes_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        json_string: '{"key": "value"}'
+        html_string: '<div class="test">content</div>'
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      final content = await outputFile.readAsString();
+
+      // Verify that double quotes are not escaped with backslashes
+      expect(content, contains('const jsonString = \'{"key": "value"}\';'));
+      expect(content, contains('const htmlString = \'<div class="test">content</div>\';'));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
 }


### PR DESCRIPTION
Fixes unnecessary string escapes in generated Dart constants.

This PR adds real value by improving Developer Experience (DX) and code quality. Previously, generating strings containing double quotes (e.g. JSON strings) would result in backslash-escaped double quotes (`\"`) inside single-quoted strings (e.g., `'{\"key\": \"value\"}'`). This generated unnecessary code noise and triggered the standard Dart analyzer warning `unnecessary_string_escapes`, littering the developer's project with linter issues. By stripping out `\"` in favor of `"`, the generated code is cleaner and passes `dart analyze` perfectly.

---
*PR created automatically by Jules for task [2819294200272559815](https://jules.google.com/task/2819294200272559815) started by @insign*