### PR TITLE
fix: prevent unnecessary double quote escapes to avoid linter warnings

### DIFF
--- a/lib/src/yaml2dart_base.dart
+++ b/lib/src/yaml2dart_base.dart
@@ -34,7 +34,8 @@ class Yaml2Dart {
       final escaped = encoded
           .substring(1, encoded.length - 1)
           .replaceAll("'", r"\'")
-          .replaceAll(r'$', r'\$');
+          .replaceAll(r'$', r'\$')
+          .replaceAll(r'\"', '"');
       return "'$escaped'";
     }
     if (value is num || value is bool) {

--- a/test/yaml2dart_test.dart
+++ b/test/yaml2dart_test.dart
@@ -150,6 +150,33 @@ const author = 'John Doe';
     }
   });
 
+  test('Does not unnecessarily escape double quotes in string constants', () async {
+    final tempDir = await Directory.systemTemp.createTemp('yaml2dart_quotes_test_');
+    final inputPath = path.join(tempDir.path, 'quotes_input.yaml');
+    final outputPath = path.join(tempDir.path, 'quotes_output.dart');
+
+    try {
+      final inputFile = File(inputPath);
+      await inputFile.writeAsString('''
+        message: 'say "hello"'
+        other: "it's \\"ok\\""
+''');
+
+      final converter = Yaml2Dart(inputPath, outputPath);
+      await converter.convert();
+
+      final outputFile = File(outputPath);
+      expect(await outputFile.exists(), isTrue);
+      final content = await outputFile.readAsString();
+
+      // Verify strings do not contain unnecessarily escaped double quotes
+      expect(content, contains("const message = 'say \"hello\"';"));
+      expect(content, contains("const other = 'it\\'s \"ok\"';"));
+    } finally {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
   test('Sanitizes Dart reserved keywords and keys starting with digits', () async {
     final tempDir = await Directory.systemTemp.createTemp('yaml2dart_sanitize_test_');
     final inputPath = path.join(tempDir.path, 'sanitize_input.yaml');


### PR DESCRIPTION
O PR remove o escape desnecessário de aspas duplas em strings constantes geradas para evitar warnings do linter `unnecessary_string_escapes` nos projetos dos usuários.

Isso melhora significativamente a experiência de desenvolvimento (DevEx), pois impede que o código gerado pelo pacote adicione ruído e poluição visual devido a avisos do linter no projeto onde o pacote é utilizado. 

**Alterações:**
*   **Código:** O método `_formatValue` no arquivo `lib/src/yaml2dart_base.dart` agora remove o escape `\"` gerado pelo `jsonEncode` trocando-o por `"`, já que os valores de string são sempre envelopados em aspas simples (`'...'`) no Dart.
*   **Testes:** Foi adicionado o caso de teste `'Does not unnecessarily escape double quotes in string constants'` no arquivo `test/yaml2dart_test.dart` para garantir que aspas duplas, inclusive dentro de outras strings, não sejam scaped com barra invertida indevidamente.

Nenhum arquivo `.md` foi atualizado pois as alterações não invalidam ou alteram o conteúdo da documentação existente.

**Testes:**
A mudança foi validada localmente rodando `dart test` para assegurar que nenhum comportamento quebrou e `dart analyze` para garantir que o código submetido atende aos requisitos do linter. O próprio código Dart gerado agora também não deve disparar avisos do linter para esses casos de aspas duplas inseridas dentro de aspas simples.

---
*PR created automatically by Jules for task [18422972582566481592](https://jules.google.com/task/18422972582566481592) started by @insign*