### PR TITLE
feat: add CLI support for yaml2dart

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,21 @@
 
 Converts a YAML file to a Dart file containing global scope constants. It allows developers to easily use YAML data in their Dart projects by generating a separate file with all the YAML data as constants. Especially good for `pubspec.yaml`.
 
+## CLI Usage
+
+To use it globally:
+
+```bash
+dart pub global activate yaml2dart
+yaml2dart pubspec.yaml pubspec.dart
+```
+
+Or run it without installing globally:
+
+```bash
+dart run yaml2dart pubspec.yaml pubspec.dart
+```
+
 ## Getting started
 
 ```dart

--- a/bin/yaml2dart.dart
+++ b/bin/yaml2dart.dart
@@ -1,0 +1,28 @@
+import 'dart:io';
+import 'package:yaml2dart/yaml2dart.dart';
+
+void main(List<String> args) async {
+  if (args.length != 2) {
+    stderr.writeln('Usage: dart run yaml2dart <input.yaml> <output.dart>');
+    exit(1);
+  }
+
+  final inputFilePath = args[0];
+  final outputFilePath = args[1];
+
+  final inputFile = File(inputFilePath);
+  if (!await inputFile.exists()) {
+    stderr.writeln('Error: Input file "$inputFilePath" does not exist.');
+    exit(1);
+  }
+
+  final converter = Yaml2Dart(inputFilePath, outputFilePath);
+
+  try {
+    await converter.convert();
+    stdout.writeln('Successfully generated "$outputFilePath" from "$inputFilePath".');
+  } catch (e) {
+    stderr.writeln('Error: $e');
+    exit(1);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,6 +3,9 @@ description: Converts a YAML file to a Dart file containing global scope constan
 version: 1.5.1
 repository: https://github.com/insign/dart_yaml2dart
 
+executables:
+  yaml2dart:
+
 environment:
   sdk: '>=3.6.2 <4.0.0'
 


### PR DESCRIPTION
This PR adds a Command Line Interface (CLI) to `yaml2dart`, enabling developers to run the tool globally or directly from the command line without writing custom Dart scripts. This is a significant improvement to the Developer Experience (DX), making the tool much more accessible and easier to integrate into build pipelines.

- Added `bin/yaml2dart.dart` as the main CLI entry point.
- Configured the executable in `pubspec.yaml` under the `executables` key.
- Updated `README.md` to document the new CLI usage.

---
*PR created automatically by Jules for task [4811256560178379679](https://jules.google.com/task/4811256560178379679) started by @insign*