### PR TITLE
feat: Add CLI executable to improve Developer Experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,30 @@ Converts a YAML file to a Dart file containing global scope constants. It allows
 
 ## Getting started
 
-```dart
+```bash
 dart pub add yaml2dart
 ```
 
 ## Usage
+
+### Command Line (CLI)
+
+The easiest way to use `yaml2dart` is directly from the command line.
+
+```bash
+dart run yaml2dart example.yaml lib/example_constants.dart
+```
+
+Alternatively, you can activate it globally:
+
+```bash
+dart pub global activate yaml2dart
+yaml2dart example.yaml lib/example_constants.dart
+```
+
+### In Code
+
+You can also use it programmatically in your Dart scripts.
 
 Assuming that the `example.yaml` file contains the following:
 

--- a/bin/yaml2dart.dart
+++ b/bin/yaml2dart.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+import 'package:yaml2dart/yaml2dart.dart';
+
+void main(List<String> args) async {
+  if (args.length != 2) {
+    print('Usage: dart run yaml2dart <input.yaml> <output.dart>');
+    exit(1);
+  }
+
+  final inputFilePath = args[0];
+  final outputFilePath = args[1];
+
+  try {
+    final converter = Yaml2Dart(inputFilePath, outputFilePath);
+    await converter.convert();
+    print('Successfully converted $inputFilePath to $outputFilePath');
+  } catch (e) {
+    print('Error converting YAML to Dart: $e');
+    exit(1);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,3 +14,6 @@ dev_dependencies:
 dependencies:
   recase: ^4.1.0
   yaml: ^3.1.3
+
+executables:
+  yaml2dart:


### PR DESCRIPTION
Adds a CLI executable for `yaml2dart` to significantly improve the developer experience. Previously, users had to write their own Dart script wrapper to use the converter. With this update, users can execute the conversion directly from the command line using `dart run yaml2dart <input.yaml> <output.dart>` or globally after activation.

---
*PR created automatically by Jules for task [14197091087523294959](https://jules.google.com/task/14197091087523294959) started by @insign*